### PR TITLE
Add geopy version 2.4.1 to requirements

### DIFF
--- a/agentenv-tool/Toolusage/requirements.txt
+++ b/agentenv-tool/Toolusage/requirements.txt
@@ -7,3 +7,4 @@ requests==2.27.1
 requests_mock
 typing_extensions==4.5.0
 typing-inspect==0.8.0
+geopy==2.4.1


### PR DESCRIPTION
If you configure the environment according to the current requirements document, when attempting to start the weather server, you will find that the geopy dependency is missing:

weather --host 0.0.0.0 --port 8000

Traceback (most recent call last):
  File "/root/miniconda3/envs/agentenv-tool/bin/weather", line 5, in <module>
    from agentenv_weather import launch
  File "/wangyifan/AgentGym/agentenv-tool/agentenv_weather/__init__.py", line 9, in <module>
    from .weather_server import app
  File "/wangyifan/AgentGym/agentenv-tool/agentenv_weather/weather_server.py", line 9, in <module>
    from .weather_environment import weather_env_server
  File "/wangyifan/AgentGym/agentenv-tool/agentenv_weather/weather_environment.py", line 7, in <module>
    from environment.weather_env import WeatherEnv
  File "/wangyifan/AgentGym/agentenv-tool/Toolusage/toolusage/environment/weather_env.py", line 7, in <module>
    from utils.weather.weather_tools import weather_toolkits
  File "/wangyifan/AgentGym/agentenv-tool/Toolusage/toolusage/utils/weather/weather_tools.py", line 3, in <module>
    from geopy.distance import geodesic
ModuleNotFoundError: No module named 'geopy'

Adding this dependency will resolve the issue.